### PR TITLE
docs: add more snapcraft metadata fields

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -8,6 +8,9 @@ base: core20
 confinement: classic
 license: GPL-3.0
 issues: https://github.com/toabctl/chimg/issues
+website: https://github.com/toabctl/chimg
+source-code: https://github.com/toabctl/chimg
+contact: thomas.bechtold@canonical.com
 
 apps:
   chimg:


### PR DESCRIPTION
To have more information available on the snapstore.io page.