### PR TITLE
test: add functional test to install deb packages

### DIFF
--- a/chimg/tests/functional/configs/deb-only.yaml
+++ b/chimg/tests/functional/configs/deb-only.yaml
@@ -1,0 +1,8 @@
+---
+# a config testing only deb package installation
+debs:
+  - name: chrony
+  - name: fuse3
+    hold: true
+  - name: ec2-hibinit-agent
+    hold: false


### PR DESCRIPTION
Do test a couple of different packages (including packages which do contain systemd services) and do test the apt hold mechanism.