### PR TITLE
fix: add rustc build-packages to snapcraft.yaml

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -24,6 +24,8 @@ parts:
     override-build: |
       snapcraftctl build
       ln -sf ../usr/bin/python3.10 $SNAPCRAFT_PART_INSTALL/bin/python3
+    build-packages:
+      - rustc
     stage-packages:
       - squashfs-tools
       - python3-venv


### PR DESCRIPTION
That hopefully helps with the riscv builds.