### PR TITLE
fix: allow downgrades for deb installs via apt

### DIFF
--- a/chimg/chroot.py
+++ b/chimg/chroot.py
@@ -304,7 +304,15 @@ class Chroot:
         Use _debs_install() to install all configured deb packages
         """
         run_command(
-            ["/usr/sbin/chroot", self._ctx.chroot_path, "apt-get", "install", "--assume-yes", deb["name"]],
+            [
+                "/usr/sbin/chroot",
+                self._ctx.chroot_path,
+                "apt-get",
+                "install",
+                "--assume-yes",
+                "--allow-downgrades",
+                deb["name"],
+            ],
             env={"DEBIAN_FRONTEND": "noninteractive"},
         )
         if deb.get("hold", False):

--- a/chimg/tests/test_chroot.py
+++ b/chimg/tests/test_chroot.py
@@ -48,7 +48,15 @@ def test__deb_install(mock_subprocess, chroot_dir, deb):
     cr = chroot.Chroot(ctx)
     cr._deb_install(deb)
     mock_subprocess.assert_any_call(
-        ["/usr/sbin/chroot", chroot_dir.as_posix(), "apt-get", "install", "--assume-yes", deb["name"]],
+        [
+            "/usr/sbin/chroot",
+            chroot_dir.as_posix(),
+            "apt-get",
+            "install",
+            "--assume-yes",
+            "--allow-downgrades",
+            deb["name"],
+        ],
         cwd=None,
         env={"DEBIAN_FRONTEND": "noninteractive"},
         capture_output=True,


### PR DESCRIPTION
That's required when eg. using PPAs with high priorities and packages with lower versions will be installed (eg. in the FIPS case).